### PR TITLE
fix ServiceAccount name

### DIFF
--- a/cluster/namespace/spring-petclinic-rolebinding.yaml
+++ b/cluster/namespace/spring-petclinic-rolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: admin
 subjects:
 - kind: ServiceAccount
-  name: argocd-cluster-argocd-application-controller
+  name: openshift-gitops-argocd-application-controller
   namespace: openshift-gitops


### PR DESCRIPTION
Hi, I found an error while performing the steps in the following document.

- [Deploying a Spring Boot application with Argo CD | CI/CD | OpenShift Container Platform 4.8](https://docs.openshift.com/container-platform/4.8/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/deploying-a-spring-boot-application-with-argo-cd.html)

I created a `spring-petclinic` application with the ArgoCD UI, but it was not deployed with the following error:

```log
deployments.apps is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller" cannot create resource "deployments" in API group "apps" in the namespace "spring-petclinic"
```

The cause of above error was that the ServiceAccount name of the RoleBinding created did not match the above ( `openshift-gitops-argocd-application-controller` ).

So I fixed it and confirmed that the application deployed successfully.