### PR TITLE
Use service-binding spring-petclinic image

### DIFF
--- a/app/deployment.yaml
+++ b/app/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: spring-petclinic
         imagePullPolicy: Always
-        image: quay.io/siamaksade/spring-petclinic:latest
+        image: quay.io/service-binding/spring-petclinic:latest
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
The spring-petclinic build from Service Binding Operator is multi-arch enabled and maintained through their source repository.

This is important for the IBM Power & Z enablement of GitOps.
