### PR TITLE
fix: missing main branch in upstream

### DIFF
--- a/argo/app.yaml
+++ b/argo/app.yaml
@@ -12,7 +12,7 @@ spec:
     directory:
       recurse: true
     path: app
-    repoURL: https://github.com/siamaksade/openshift-gitops-getting-started.git
+    repoURL: https://github.com/redhat-developer/openshift-gitops-getting-started.git
     targetRevision: main
   syncPolicy:
     automated:


### PR DESCRIPTION
This could provide a temporary workaround for https://github.com/openshift/openshift-docs/issues/47702, but there might be other divergences that need to be accounted for.