### PR TITLE
fix: namespace is not created by default

### DIFF
--- a/argo/app.yaml
+++ b/argo/app.yaml
@@ -15,6 +15,8 @@ spec:
     repoURL: https://github.com/siamaksade/openshift-gitops-getting-started.git
     targetRevision: main
   syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true


### PR DESCRIPTION
This is required for the [OC CLI doc example](https://docs.openshift.com/container-platform/4.10/cicd/gitops/deploying-a-spring-boot-application-with-argo-cd.html#creating-an-application-by-using-the-oc-tool_deploying-a-spring-boot-application-with-argo-cd) to work. Specifically, the `oc label` command.