### PR TITLE
Adding manifests for custom cluster role demo

### DIFF
--- a/customclusterrole/namespace.yaml
+++ b/customclusterrole/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-gitops-ns

--- a/customclusterrole/persistentvolumes.yaml
+++ b/customclusterrole/persistentvolumes.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-gitops-pv
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadOnlyMany
+  hostPath:
+    path: "/mnt/data"


### PR DESCRIPTION
This PR is to add manifests for Custom Cluster Role feature demo, that will be available in OpenShift GitOps Documents in 1.13 release.